### PR TITLE
Prevent sending messages containing 'Tsunami' to Slack

### DIFF
--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -105,16 +105,18 @@ export default async function sendMessage(
 
   // Post to Slack
   if (env.SLACK_BOT_TOKEN !== undefined && env.SLACK_CHANNEL_ID !== undefined) {
-    const attachments = createSlackMessage(text);
+    if (!text.includes('Tsunami')) {
+      const attachments = createSlackMessage(text);
 
-    try {
-      await slackClient.chat.postMessage({
-        channel: env.SLACK_CHANNEL_ID,
-        attachments: attachments,
-      });
-      logger.info('Message successfully sent to Slack');
-    } catch (slackError) {
-      logger.error('Error during Slack message send:', slackError);
+      try {
+        await slackClient.chat.postMessage({
+          channel: env.SLACK_CHANNEL_ID,
+          attachments: attachments,
+        });
+        logger.info('Message successfully sent to Slack');
+      } catch (slackError) {
+        logger.error('Error during Slack message send:', slackError);
+      }
     }
   }
 


### PR DESCRIPTION
## Overview

This pull request is a temporary measure to prevent sending messages in a part of the system that generates attachments for Slack messages, as it is not compliant with tsunami requirements.

### Changes Made

- Implemented a fix to prevent sending messages if they contain the word "tsunami".

### Issues Resolved

Fixed an issue where messages were still being processed even when they were not tsunami compliant.

## Checklist

- [x] The code follows the style guide.
- [x] Tests have been run and all tests have passed.
- [x] Documentation has been updated where necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a safeguard to prevent messages containing the word "Tsunami" from being sent to Slack.
  
- **Bug Fixes**
	- Enhanced message filtering to ensure compliance with content guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->