### PR TITLE
Exclude New Relic logs during development

### DIFF
--- a/src/messages/handle.ts
+++ b/src/messages/handle.ts
@@ -1,6 +1,4 @@
 import type { AtpAgent } from '@atproto/api';
-import nrPino from '@newrelic/pino-enricher';
-import pino from 'pino';
 import parseArea from '../parsers/area';
 import parseCode from '../parsers/code';
 import parsePoints from '../parsers/points';
@@ -8,14 +6,16 @@ import parseScale from '../parsers/scale';
 import type { JMAQuake, JMATsunami } from '../types';
 import { createEarthquakeMessage, createTsunamiMessage } from './create';
 import sendMessage from './send';
-
-const logger = pino(nrPino());
+import { getLogger } from '..';
 
 export async function handleEarthquake(
   earthquakeData: JMAQuake,
   agent: AtpAgent,
   isDev: boolean,
 ): Promise<void> {
+  // Get the logger
+  const logger = await getLogger();
+
   const code = earthquakeData.code;
   const info = parseCode(code);
   const points = parsePoints(earthquakeData.points);
@@ -38,6 +38,9 @@ export async function handleTsunami(
   agent: AtpAgent,
   isDev: boolean,
 ): Promise<void> {
+  // Get the logger
+  const logger = await getLogger();
+
   const code = tsunamiData.code;
   const info = parseCode(code);
   const area = parseArea(tsunamiData.areas);

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -1,19 +1,17 @@
 import { WebClient } from '@slack/web-api';
 import https from 'node:https';
 import { type AtpAgent, RichText } from '@atproto/api';
-import nrPino from '@newrelic/pino-enricher';
 import { createRestAPIClient } from 'masto';
 import { decode } from 'nostr-tools/nip19';
 import { finalizeEvent, getPublicKey } from 'nostr-tools/pure';
 import { Relay, useWebSocketImplementation } from 'nostr-tools/relay';
-import pino from 'pino';
 import WebSocket from 'ws';
 import env from '../env';
 import { createSlackMessage } from './create';
+import { getLogger } from '..';
 
 useWebSocketImplementation(WebSocket);
 
-const logger = pino(nrPino());
 const slackClient = new WebClient(env.SLACK_BOT_TOKEN); // Slack Web API Client
 const MASTODON_URL: string = env.MASTODON_URL ?? 'https://mastodon.social';
 
@@ -30,6 +28,8 @@ export default async function sendMessage(
   text: string,
   agent: AtpAgent | undefined,
 ): Promise<void> {
+  const logger = await getLogger();
+
   // Post to Bluesky
   if (agent?.session !== undefined) {
     const rt = new RichText({ text });


### PR DESCRIPTION
## Overview

This pull request introduces changes to prevent New Relic logs from being output during development environments. By excluding these logs, we reduce unnecessary noise and improve log readability for developers during the development process.

### Changes Made

- New Relic logging has been disabled for the development environment.
- Adjustments to the logging configuration to ensure New Relic logs are excluded during development but remain enabled in production and other environments.

### Issues Resolved

- This pull request resolves the issue of excessive and unnecessary New Relic logs cluttering the output during development, which can make debugging and log analysis more difficult for developers.

## Checklist

- [x] The code follows the style guide.
- [x] Tests have been run and all tests have passed.
- [x] Documentation has been updated where necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an asynchronous logger initialization for improved logging efficiency.
	- Added a new `getLogger` function to ensure the logger is properly initialized before use.

- **Bug Fixes**
	- Enhanced logging mechanisms in various functions to avoid issues with uninitialized loggers.

- **Refactor**
	- Modified multiple functions to utilize the new asynchronous logger setup, ensuring consistent logging behavior throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->